### PR TITLE
feat: added UTxORPC provider

### DIFF
--- a/packages/mesh-provider/package.json
+++ b/packages/mesh-provider/package.json
@@ -35,7 +35,9 @@
   "dependencies": {
     "@meshsdk/common": "*",
     "@meshsdk/core-cst": "*",
-    "axios": "^1.7.2"
+    "axios": "^1.7.2",
+    "@utxorpc/sdk": "0.4.0",
+    "@utxorpc/spec": "0.9.0"
   },
   "prettier": "@meshsdk/configs/prettier",
   "publishConfig": {

--- a/packages/mesh-provider/src/u5c.ts
+++ b/packages/mesh-provider/src/u5c.ts
@@ -70,8 +70,8 @@ export class U5CProvider implements IFetcher, ISubmitter {
   }
 
   async fetchAddressUTxOs(address: string, asset?: string): Promise<UTxO[]> {
-    const addressA = Address.fromString(address);
-    const addressBytes = toBytes(addressA!.toBytes().toString())
+    const addressObj = Address.fromString(address);
+    const addressBytes = toBytes(addressObj!.toBytes().toString())
 
     let utxoSearchResult: Utxo[];
 
@@ -226,27 +226,26 @@ export class U5CProvider implements IFetcher, ISubmitter {
 
   private _rpcPParamsToCorePParams(rpcPParams: Cardano.PParams): Protocol {
     return {
-      epoch: 1, // Hard coded response
-      minFeeA: Number(rpcPParams.minFeeConstant), // Adjusted from 'minFeeConstant'
-      minFeeB: Number(rpcPParams.minFeeCoefficient), // Adjusted from 'minFeeCoefficient'
+      epoch: 1, 
+      minFeeA: Number(rpcPParams.minFeeConstant), 
+      minFeeB: Number(rpcPParams.minFeeCoefficient), 
       maxBlockSize: Number(rpcPParams.maxBlockBodySize),
       maxTxSize: Number(rpcPParams.maxTxSize),
       maxBlockHeaderSize: Number(rpcPParams.maxBlockHeaderSize),
-      keyDeposit: Number(rpcPParams.stakeKeyDeposit), // Assuming 'keyDeposit' maps to 'stakeKeyDeposit'
-      poolDeposit: Number(rpcPParams.poolDeposit),
-      decentralisation: Number(rpcPParams.poolInfluence?.numerator), // Assuming 'decentralisation' is mapped from 'poolInfluence'
+      keyDeposit: Number(rpcPParams.stakeKeyDeposit), 
+      decentralisation: Number(rpcPParams.poolInfluence?.numerator),
       minPoolCost: String(rpcPParams.minPoolCost),
-      priceMem: Number(rpcPParams.prices?.memory), // Adjusted from 'prices.memory'
-      priceStep: Number(rpcPParams.prices?.steps), // Adjusted from 'prices.steps'
-      maxTxExMem: String(rpcPParams.maxExecutionUnitsPerTransaction?.memory), // Adjusted from 'maxExecutionUnitsPerTransaction.memory'
-      maxTxExSteps: String(rpcPParams.maxExecutionUnitsPerTransaction?.steps), // Adjusted from 'maxExecutionUnitsPerTransaction.steps'
-      maxBlockExMem: String(rpcPParams.maxExecutionUnitsPerBlock?.memory), // Adjusted from 'maxExecutionUnitsPerBlock.memory'
-      maxBlockExSteps: String(rpcPParams.maxExecutionUnitsPerBlock?.steps), // Adjusted from 'maxExecutionUnitsPerBlock.steps'
+      priceMem: Number(rpcPParams.prices?.memory),
+      priceStep: Number(rpcPParams.prices?.steps), 
+      maxTxExMem: String(rpcPParams.maxExecutionUnitsPerTransaction?.memory), 
+      maxTxExSteps: String(rpcPParams.maxExecutionUnitsPerTransaction?.steps), 
+      maxBlockExMem: String(rpcPParams.maxExecutionUnitsPerBlock?.memory), 
+      maxBlockExSteps: String(rpcPParams.maxExecutionUnitsPerBlock?.steps),
       maxValSize: Number(rpcPParams.maxValueSize),
-      collateralPercent: Number(rpcPParams.collateralPercentage), // Adjusted from 'collateralPercentage'
+      collateralPercent: Number(rpcPParams.collateralPercentage), 
       maxCollateralInputs: Number(rpcPParams.maxCollateralInputs),
-      coinsPerUtxoSize: Number(rpcPParams.coinsPerUtxoByte), // Adjusted from 'coinsPerUtxoByte'
-      minFeeRefScriptCostPerByte: Number(rpcPParams.minFeeConstant), // Assuming a mapping for 'minFeeRefScriptCostPerByte'
+      coinsPerUtxoSize: Number(rpcPParams.coinsPerUtxoByte), 
+      minFeeRefScriptCostPerByte: Number(rpcPParams.minFeeConstant), 
     };
   }
 

--- a/packages/mesh-provider/src/u5c.ts
+++ b/packages/mesh-provider/src/u5c.ts
@@ -1,0 +1,293 @@
+import { HexBlob } from "@cardano-sdk/util";
+import { CardanoQueryClient, CardanoSubmitClient } from "@utxorpc/sdk";
+import { Utxo } from "@utxorpc/sdk/lib/cardano";
+import * as Cardano from "@utxorpc/spec/lib/utxorpc/v1alpha/cardano/cardano_pb.js";
+
+import {
+  AccountInfo,
+  Asset,
+  AssetMetadata,
+  BlockInfo,
+  bytesToHex,
+  IFetcher,
+  ISubmitter,
+  Protocol,
+  toBytes,
+  TransactionInfo,
+  UTxO,
+} from "@meshsdk/common";
+import {
+  Address,
+  AssetId,
+  AssetName,
+  Datum,
+  DatumHash,
+  PlutusData,
+  PlutusV1Script,
+  PlutusV2Script,
+  PolicyId,
+  Script,
+  TokenMap,
+  TransactionId,
+  TransactionInput,
+  TransactionOutput,
+  Value,
+} from "@meshsdk/core-cst";
+
+export class U5CProvider implements IFetcher, ISubmitter {
+  private queryClient: CardanoQueryClient;
+  private submitClient: CardanoSubmitClient;
+
+  constructor({
+    url,
+    headers,
+  }: {
+    url: string;
+    headers?: Record<string, string>;
+  }) {
+    this.queryClient = new CardanoQueryClient({
+      uri: url,
+      headers,
+    });
+
+    this.submitClient = new CardanoSubmitClient({
+      uri: url,
+      headers,
+    });
+  }
+
+  async submitTx(tx: string): Promise<string> {
+    const txHash = await this.submitClient.submitTx(toBytes(tx));
+    return bytesToHex(txHash);
+  }
+
+  async fetchProtocolParameters(epoch: number): Promise<Protocol> {
+    const rpcPParams = await this.queryClient.readParams();
+    if (rpcPParams === undefined || rpcPParams === null) {
+      throw new Error(`Error fetching protocol parameters`);
+    }
+    return this._rpcPParamsToCorePParams(rpcPParams);
+  }
+
+  async fetchAddressUTxOs(address: string, asset?: string): Promise<UTxO[]> {
+    const addressA = Address.fromString(address);
+    const addressBytes = toBytes(addressA!.toBytes().toString())
+
+    let utxoSearchResult: Utxo[];
+
+    if (asset) {
+      const policyId = asset.substring(0, 56);
+      const name = asset.length > 56 ? asset : undefined;
+
+      if (name) {
+        // Call searchUtxosByAddressWithAsset if both policyId and name are present
+        const assetNameBytes = toBytes(name);;
+        utxoSearchResult = await this.queryClient.searchUtxosByAddressWithAsset(
+          addressBytes,
+          undefined,
+          assetNameBytes,
+        );
+      } else {
+        // Call searchUtxosByAddressWithAsset using only the policyId
+        const policyIdBytes = toBytes(policyId);
+        utxoSearchResult = await this.queryClient.searchUtxosByAddressWithAsset(
+          addressBytes,
+          policyIdBytes,
+          undefined,
+        );
+      }
+    } else {
+      // Call searchUtxosByAddress if no asset is provided
+      utxoSearchResult =
+        await this.queryClient.searchUtxosByAddress(addressBytes);
+    }
+
+    return utxoSearchResult.map((item) => {
+      const input = new TransactionInput(
+        TransactionId(Buffer.from(item.txoRef.hash).toString("hex")),
+        BigInt(item.txoRef.index),
+      );
+
+      const output = this._rpcTxOutToCoreTxOut(item.parsedValued!);
+
+      return this.toUTxO({ input, output }, address);
+    });
+  }
+
+  private toUTxO(
+    output: { input: TransactionInput; output: TransactionOutput },
+    address: string,
+  ): UTxO {
+    const { input, output: txOutput } = output;
+
+    return {
+      input: {
+        outputIndex: Number(input.index()),
+        txHash: input.transactionId().toString(),
+      },
+      output: {
+        address: address,
+        amount: [
+          { unit: "lovelace", quantity: txOutput.amount().coin().toString() },
+          ...(txOutput.amount().multiasset()
+            ? Array.from(txOutput.amount().multiasset() ?? new Map()).map(
+                ([assetId, quantity]) => ({
+                  unit: assetId,
+                  quantity: quantity.toString(),
+                }),
+              )
+            : []),
+        ],
+        dataHash: txOutput.datum()?.asDataHash() ?? undefined,
+        plutusData: txOutput.datum()?.asInlineData()?.toString() ?? undefined,
+        scriptRef: txOutput.scriptRef()?.toString() ?? undefined,
+        scriptHash: txOutput.scriptRef()?.hash() ?? undefined,
+      },
+    };
+  }
+  private _rpcTxOutToCoreTxOut(
+    rpcTxOutput: Cardano.TxOutput,
+  ): TransactionOutput {
+    const output = new TransactionOutput(
+      Address.fromBytes(HexBlob.fromBytes(rpcTxOutput.address)),
+      this._rpcTxOutToCoreValue(rpcTxOutput),
+    );
+
+    if (rpcTxOutput.datum !== undefined) {
+      if (
+        rpcTxOutput.datum?.originalCbor &&
+        rpcTxOutput.datum.originalCbor.length > 0
+      ) {
+        const inlineDatum = Datum.newInlineData(
+          PlutusData.fromCbor(
+            HexBlob.fromBytes(rpcTxOutput.datum.originalCbor),
+          ),
+        );
+        output.setDatum(inlineDatum);
+      } else if (rpcTxOutput.datum?.hash && rpcTxOutput.datum.hash.length > 0) {
+        const datumHash = Datum.newDataHash(
+          DatumHash(Buffer.from(rpcTxOutput.datum.hash).toString("hex")),
+        );
+        output.setDatum(datumHash);
+      }
+    }
+
+    if (rpcTxOutput.script !== undefined) {
+      if (rpcTxOutput.script.script.case === "plutusV1") {
+        const cbor = rpcTxOutput.script.script.value;
+        output.setScriptRef(
+          Script.newPlutusV1Script(
+            PlutusV1Script.fromCbor(HexBlob.fromBytes(cbor)),
+          ),
+        );
+      }
+      if (rpcTxOutput.script.script.case === "plutusV2") {
+        const cbor = rpcTxOutput.script.script.value;
+        output.setScriptRef(
+          Script.newPlutusV2Script(
+            PlutusV2Script.fromCbor(HexBlob.fromBytes(cbor)),
+          ),
+        );
+      }
+    }
+
+    return output;
+  }
+
+  private _rpcTxOutToCoreValue(rpcTxOutput: Cardano.TxOutput): Value {
+    return new Value(
+      BigInt(rpcTxOutput.coin),
+      this._rpcMultiAssetOutputToTokenMap(rpcTxOutput.assets),
+    );
+  }
+
+  private _rpcMultiAssetOutputToTokenMap(
+    multiAsset: Cardano.Multiasset[],
+  ): TokenMap {
+    const tokenMap: TokenMap = new Map();
+    multiAsset.forEach((ma) => {
+      ma.assets.forEach((asset) => {
+        const assetId = AssetId.fromParts(
+          PolicyId(Buffer.from(ma.policyId).toString("hex")),
+          AssetName(Buffer.from(asset.name).toString("hex")),
+        );
+
+        const quantity = BigInt(asset.outputCoin);
+
+        if (tokenMap.has(assetId)) {
+          tokenMap.set(assetId, tokenMap.get(assetId)! + quantity);
+        } else {
+          tokenMap.set(assetId, quantity);
+        }
+      });
+    });
+    return tokenMap;
+  }
+
+  private _rpcPParamsToCorePParams(rpcPParams: Cardano.PParams): Protocol {
+    return {
+      epoch: 1, // Hard coded response
+      minFeeA: Number(rpcPParams.minFeeConstant), // Adjusted from 'minFeeConstant'
+      minFeeB: Number(rpcPParams.minFeeCoefficient), // Adjusted from 'minFeeCoefficient'
+      maxBlockSize: Number(rpcPParams.maxBlockBodySize),
+      maxTxSize: Number(rpcPParams.maxTxSize),
+      maxBlockHeaderSize: Number(rpcPParams.maxBlockHeaderSize),
+      keyDeposit: Number(rpcPParams.stakeKeyDeposit), // Assuming 'keyDeposit' maps to 'stakeKeyDeposit'
+      poolDeposit: Number(rpcPParams.poolDeposit),
+      decentralisation: Number(rpcPParams.poolInfluence?.numerator), // Assuming 'decentralisation' is mapped from 'poolInfluence'
+      minPoolCost: String(rpcPParams.minPoolCost),
+      priceMem: Number(rpcPParams.prices?.memory), // Adjusted from 'prices.memory'
+      priceStep: Number(rpcPParams.prices?.steps), // Adjusted from 'prices.steps'
+      maxTxExMem: String(rpcPParams.maxExecutionUnitsPerTransaction?.memory), // Adjusted from 'maxExecutionUnitsPerTransaction.memory'
+      maxTxExSteps: String(rpcPParams.maxExecutionUnitsPerTransaction?.steps), // Adjusted from 'maxExecutionUnitsPerTransaction.steps'
+      maxBlockExMem: String(rpcPParams.maxExecutionUnitsPerBlock?.memory), // Adjusted from 'maxExecutionUnitsPerBlock.memory'
+      maxBlockExSteps: String(rpcPParams.maxExecutionUnitsPerBlock?.steps), // Adjusted from 'maxExecutionUnitsPerBlock.steps'
+      maxValSize: Number(rpcPParams.maxValueSize),
+      collateralPercent: Number(rpcPParams.collateralPercentage), // Adjusted from 'collateralPercentage'
+      maxCollateralInputs: Number(rpcPParams.maxCollateralInputs),
+      coinsPerUtxoSize: Number(rpcPParams.coinsPerUtxoByte), // Adjusted from 'coinsPerUtxoByte'
+      minFeeRefScriptCostPerByte: Number(rpcPParams.minFeeConstant), // Assuming a mapping for 'minFeeRefScriptCostPerByte'
+    };
+  }
+
+  fetchUTxOs(hash: string): Promise<UTxO[]> {
+    throw new Error("Method not implemented.");
+  }
+
+  fetchAccountInfo(address: string): Promise<AccountInfo> {
+    throw new Error("Method not implemented.");
+  }
+
+  fetchAssetAddresses(
+    asset: string,
+  ): Promise<{ address: string; quantity: string }[]> {
+    throw new Error("Method not implemented.");
+  }
+
+  fetchAssetMetadata(asset: string): Promise<AssetMetadata> {
+    throw new Error("Method not implemented.");
+  }
+
+  fetchBlockInfo(hash: string): Promise<BlockInfo> {
+    throw new Error("Method not implemented.");
+  }
+
+  fetchCollectionAssets(
+    policyId: string,
+    cursor?: number | string,
+  ): Promise<{ assets: Asset[]; next?: string | number | null }> {
+    throw new Error("Method not implemented.");
+  }
+
+  fetchHandle(handle: string): Promise<object> {
+    throw new Error("Method not implemented.");
+  }
+
+  fetchHandleAddress(handle: string): Promise<string> {
+    throw new Error("Method not implemented.");
+  }
+
+  fetchTxInfo(hash: string): Promise<TransactionInfo> {
+    throw new Error("Method not implemented.");
+  }
+}

--- a/packages/mesh-provider/test/u5c/package.json
+++ b/packages/mesh-provider/test/u5c/package.json
@@ -1,7 +1,7 @@
 {
     "name": "u5c tester",
     "version": "0.1.0",
-    "description": "Send lovelace from one address to another",
+    "description": "Test u5c Endpoints",
     "main": "test.js",
     "type": "module",
     "scripts": {

--- a/packages/mesh-provider/test/u5c/package.json
+++ b/packages/mesh-provider/test/u5c/package.json
@@ -1,0 +1,17 @@
+{
+    "name": "u5c tester",
+    "version": "0.1.0",
+    "description": "Send lovelace from one address to another",
+    "main": "test.js",
+    "type": "module",
+    "scripts": {
+      "send": "tsx test.ts"
+    },
+    "dependencies": {
+      "@meshsdk/core": "^1.6.12",
+      "@meshsdk/common": "^1.6."
+    },
+    "devDependencies": {
+      "tsx": "^4.9.4"
+    }
+  }

--- a/packages/mesh-provider/test/u5c/test.ts
+++ b/packages/mesh-provider/test/u5c/test.ts
@@ -1,5 +1,6 @@
+import { Transaction } from '@meshsdk/core-cst';
 import { U5CProvider } from '../../src/u5c';
-import { Protocol, UTxO } from "@meshsdk/common";
+import { MeshWallet } from '@meshsdk/core';
 
 // Configuration for U5CProvider, adjust as needed
 const config = {
@@ -12,52 +13,22 @@ const config = {
 // Instantiate the U5CProvider
 const provider = new U5CProvider(config);
 
-// Sample address and asset for testing
-const sampleAddress = 'addr_test1qzdnkrpd5pqux2ctyrwj8rmzztcft92c79lj4k97dra74vhx8qcgyj7m7ge3sv5rrz4kvzkyfz9htrmttvuj4r5jau0qwl8umu';
-// Replace with actual asset ID
-const sampleAsset = '50ff9c0ff3472de54d42a6e7757580bfbdf2415d84e526ec37f90fc3'; 
-// CborHex of Tx
-const sampleTx = '84a300d9010281825820eb3b13c78f7a9b45d6db2d28bf97b8e9a344bf1428e65f2d5716903fcee74b1000018182581d6067618f8be0d882dbfe2dd5268c9901b81f9443cf0b84f61ab34c42ef1a0042007c021a000292b1a100d90102818258208e271e56aa9322ea6394f1d33873a0f82bb9a0a7536beb285a9822c43e4994a25840a4fe461feb468ecca4d28f05ec396d35ba6003fc0fc46ca5045f0c2298e5b5ca2fef1c129fcd78058347e9afc0eeedd7f6f6ac59f3d0b82354af7e348e96b402f5f6'; // Replace with actual serialized transaction
+const wallet = new MeshWallet({
+  networkId: 0, // 0: testnet, 1: mainnet
+  fetcher: provider,
+  submitter: provider,
+  key: {
+    type: 'mnemonic',
+    words: ["solution","solution","solution","solution","solution","solution","solution","solution","solution","solution","solution","solution","solution","solution","solution","solution","solution","solution","solution","solution","solution","solution","solution","solution"],
+  },
+});
 
-async function testFetchUTxOsWithAsset() {
-  try {
-    const utxos: UTxO[] = await provider.fetchAddressUTxOs(sampleAddress, sampleAsset);
-    console.log('Fetched UTxOs with asset:', JSON.stringify(utxos, null, 2)); 
-    
-  } catch (error) {
-    console.error('Error fetching UTxOs with asset:', error.message);
-  }
-}
+const tx = new Transaction({ initiator: wallet })
+  .sendLovelace(
+    'addr_test1vpvx0sacufuypa2k4sngk7q40zc5c4npl337uusdh64kv0c7e4cxr',
+    '5000000'
+  );
 
-async function testFetchUTxOsWithoutAsset() {
-  try {
-    const utxos: UTxO[] = await provider.fetchAddressUTxOs(sampleAddress);
-    console.log('Fetched UTxOs without asset:', JSON.stringify(utxos, null, 2)); 
-    
-  } catch (error) {
-    console.error('Error fetching UTxOs without asset:', error.message);
-  }
-}
-
-async function testFetchProtocolParameters() {
-  try {
-      const protocolParams: Protocol = await provider.fetchProtocolParameters(1);
-      console.log('Fetched Protocol Parameters:', JSON.stringify(protocolParams, null, 2));
-  } catch (error) {
-      console.error('Error fetching protocol parameters:', error.message);
-  }
-}
-
-async function testSubmitTx() {
-  try {
-    const txHash: string = await provider.submitTx(sampleTx);
-    console.log('Submitted Transaction, Hash:', txHash);
-  } catch (error) {
-    console.error('Error submitting transaction:', error.message);
-  }
-}
-// Run the tests
-testFetchUTxOsWithAsset();
-// testFetchUTxOsWithoutAsset();
-// testFetchProtocolParameters();
-// testSubmitTx();
+const unsignedTx = await tx.build();
+const signedTx = await wallet.signTx(unsignedTx);
+const txHash = await wallet.submitTx(signedTx);

--- a/packages/mesh-provider/test/u5c/test.ts
+++ b/packages/mesh-provider/test/u5c/test.ts
@@ -1,0 +1,63 @@
+import { U5CProvider } from '../../src/u5c';
+import { Protocol, UTxO } from "@meshsdk/common";
+
+// Configuration for U5CProvider, adjust as needed
+const config = {
+    url: "http://localhost:50051",
+    headers: {
+      "dmtr-api-key": ""
+    }
+};
+
+// Instantiate the U5CProvider
+const provider = new U5CProvider(config);
+
+// Sample address and asset for testing
+const sampleAddress = 'addr_test1qzdnkrpd5pqux2ctyrwj8rmzztcft92c79lj4k97dra74vhx8qcgyj7m7ge3sv5rrz4kvzkyfz9htrmttvuj4r5jau0qwl8umu';
+// Replace with actual asset ID
+const sampleAsset = '50ff9c0ff3472de54d42a6e7757580bfbdf2415d84e526ec37f90fc3'; 
+// CborHex of Tx
+const sampleTx = '84a300d9010281825820eb3b13c78f7a9b45d6db2d28bf97b8e9a344bf1428e65f2d5716903fcee74b1000018182581d6067618f8be0d882dbfe2dd5268c9901b81f9443cf0b84f61ab34c42ef1a0042007c021a000292b1a100d90102818258208e271e56aa9322ea6394f1d33873a0f82bb9a0a7536beb285a9822c43e4994a25840a4fe461feb468ecca4d28f05ec396d35ba6003fc0fc46ca5045f0c2298e5b5ca2fef1c129fcd78058347e9afc0eeedd7f6f6ac59f3d0b82354af7e348e96b402f5f6'; // Replace with actual serialized transaction
+
+async function testFetchUTxOsWithAsset() {
+  try {
+    const utxos: UTxO[] = await provider.fetchAddressUTxOs(sampleAddress, sampleAsset);
+    console.log('Fetched UTxOs with asset:', JSON.stringify(utxos, null, 2)); 
+    
+  } catch (error) {
+    console.error('Error fetching UTxOs with asset:', error.message);
+  }
+}
+
+async function testFetchUTxOsWithoutAsset() {
+  try {
+    const utxos: UTxO[] = await provider.fetchAddressUTxOs(sampleAddress);
+    console.log('Fetched UTxOs without asset:', JSON.stringify(utxos, null, 2)); 
+    
+  } catch (error) {
+    console.error('Error fetching UTxOs without asset:', error.message);
+  }
+}
+
+async function testFetchProtocolParameters() {
+  try {
+      const protocolParams: Protocol = await provider.fetchProtocolParameters(1);
+      console.log('Fetched Protocol Parameters:', JSON.stringify(protocolParams, null, 2));
+  } catch (error) {
+      console.error('Error fetching protocol parameters:', error.message);
+  }
+}
+
+async function testSubmitTx() {
+  try {
+    const txHash: string = await provider.submitTx(sampleTx);
+    console.log('Submitted Transaction, Hash:', txHash);
+  } catch (error) {
+    console.error('Error submitting transaction:', error.message);
+  }
+}
+// Run the tests
+testFetchUTxOsWithAsset();
+// testFetchUTxOsWithoutAsset();
+// testFetchProtocolParameters();
+// testSubmitTx();

--- a/packages/mesh-provider/test/u5c/test.ts
+++ b/packages/mesh-provider/test/u5c/test.ts
@@ -1,34 +1,61 @@
+// Step #1
+// Import necessary modules from Mesh SDK and U5CProvider
 import { Transaction } from '@meshsdk/core-cst';
 import { U5CProvider } from '../../src/u5c';
 import { MeshWallet } from '@meshsdk/core';
 
-// Configuration for U5CProvider, adjust as needed
+// Step #2
+// Configuration for U5CProvider
+// Replace the URL with your local or hosted UTXO provider endpoint
 const config = {
     url: "http://localhost:50051",
     headers: {
-      "dmtr-api-key": ""
+        "dmtr-api-key": "" // Add your API key here if required
     }
 };
 
-// Instantiate the U5CProvider
+// Step #3
+// Instantiate the U5CProvider with the provided configuration
 const provider = new U5CProvider(config);
 
+// Step #4
+// Create a new MeshWallet instance using a mnemonic
+// Specify the network ID (0 for testnet, 1 for mainnet)
+// The wallet uses the U5CProvider for fetching and submitting transactions
 const wallet = new MeshWallet({
-  networkId: 0, // 0: testnet, 1: mainnet
-  fetcher: provider,
-  submitter: provider,
-  key: {
-    type: 'mnemonic',
-    words: ["solution","solution","solution","solution","solution","solution","solution","solution","solution","solution","solution","solution","solution","solution","solution","solution","solution","solution","solution","solution","solution","solution","solution","solution"],
-  },
+    networkId: 0, // Testnet
+    fetcher: provider,
+    submitter: provider,
+    key: {
+        type: 'mnemonic',
+        words: [
+            "solution", "solution", "solution", "solution", "solution", "solution", 
+            "solution", "solution", "solution", "solution", "solution", "solution", 
+            "solution", "solution", "solution", "solution", "solution", "solution", 
+            "solution", "solution", "solution", "solution", "solution", "solution"
+        ],
+    },
 });
 
+// Step #5
+// Create a new transaction that sends 5 ADA to a specified address
 const tx = new Transaction({ initiator: wallet })
-  .sendLovelace(
-    'addr_test1vpvx0sacufuypa2k4sngk7q40zc5c4npl337uusdh64kv0c7e4cxr',
-    '5000000'
-  );
+    .sendLovelace(
+        'addr_test1vpvx0sacufuypa2k4sngk7q40zc5c4npl337uusdh64kv0c7e4cxr',
+        '5000000' // 5 ADA
+    );
 
+// Step #6
+// Build the transaction to prepare it for signing
 const unsignedTx = await tx.build();
+
+// Step #7
+// Sign the transaction using the wallet's private key
 const signedTx = await wallet.signTx(unsignedTx);
+
+// Step #8
+// Submit the signed transaction to the blockchain network
 const txHash = await wallet.submitTx(signedTx);
+
+// Optional: Print the transaction hash
+console.log("Transaction Hash:", txHash);


### PR DESCRIPTION
Adding UTxORPC for Mesh

This PR introduces the `U5CProvider` class, which implements the `IFetcher` and `ISubmitter` interfaces, providing a streamlined way to interact with the blockchain with U5C. Key functionalities include submitting transactions and fetching UTxOs and protocol parameters.

#### Features:
- **Transaction Submission**: Allows submitting signed transactions using the `submitTx` method, which accepts a string CborHex of a tx.
- **Fetch UTxOs by Address and Asset**: Implements `fetchAddressUTxOs` to query UTxOs associated with a specific address, with optional filtering by asset. This method handles both scenarios where an asset policy ID and asset name are provided or when only a policy ID is given.
- **Fetch Protocol Parameters**: Provides the ability to fetch protocol parameters for a specific epoch, converting them to a more accessible format through the `fetchProtocolParameters` method.
- **Utility Functions**: Includes several private utility methods such as `_rpcPParamsToCorePParams` and `_rpcTxOutToCoreTxOut` to handle conversions between RPC data structures and the core SDK types.

#### Integration:
- The provider is configured using a URL and optional headers, making it adaptable to different U5C node setups.
- A basic setup example is provided, demonstrating how to instantiate the provider and use it to submit transactions and fetch UTxOs.

#### Testing:
- Sample code is included to test the functionality of `submitTx` and `fetchAddressUTxOs` with a test address, asset, and transaction.
